### PR TITLE
Adds Archer VR600 Compatibility (to README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 An example implementation of authentication and E2E comms. via the /cgi_gdpr API endpoint on official TP-Link firmware.
 
 ### Compatible (tested) versions
+#### TD-W9960
 * **Firmware:** 1.2.0 0.8.0 v009d.0 Build 201016 Rel.78709n
 * **Hardware:** TD-W9960 v1 00000000 (TD-W9960 V1.20 - blue case)
+#### Archer VR600
+* **Firmware:** 1.4.0 0.9.1 v009e.0 Build 210826 Rel.42166n
+* **Hardware:** Archer VR600 v3 00000000
 
 ### Example usage
 ```


### PR DESCRIPTION
I wanted to automate getting the DSL status to debug some problems with someone else's router... this lib works fine as-is with the Archer VR600:
```
{
    'status': 'Up',
    'modulationType': 'VDSL2',
    'X_TP_AdslModulationCfg': 'Multimode',
    'upstreamCurrRate': '5403',
    'downstreamCurrRate': '23927',
    'X_TP_AnnexType': 'Annex auto',
    'upstreamMaxRate': '5388',
    'downstreamMaxRate': '36983',
    'upstreamNoiseMargin': '60',
    'downstreamNoiseMargin': '60',
    'upstreamAttenuation': '4',
    'downstreamAttenuation': '214',
    'X_TP_UpTime': '28480',
    'ATUCCRCErrors': '0',
    'CRCErrors': '395',
    'ATUCFECErrors': '2',
    'FECErrors': '2808783',
    'severelyErroredSecs': '0',
    'X_TP_US_SeverelyErroredSecs': '0',
    'erroredSecs': '0',
    'X_TP_US_ErroredSecs': '0'
}
```

Thank you for putting the work in to automate the horrible GDPR login/crypto stuff!